### PR TITLE
Add T330 to ShockerModelType enum

### DIFF
--- a/Types/ShockerModelType.fbs
+++ b/Types/ShockerModelType.fbs
@@ -3,5 +3,6 @@ namespace OpenShock.Serialization.Types;
 enum ShockerModelType : uint8 {
   CaiXianlin = 0,
   Petrainer = 1,
-  Petrainer998DR = 2
+  Petrainer998DR = 2,
+  T330 = 3
 }


### PR DESCRIPTION
Adds an entry for the T330 shocker to the `ShockerModelType` enum.