### PR TITLE
CI action to ensure schema conformity on incoming PRs

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+    types: [opened, reopened, synchronize]
+  workflow_call:
+  workflow_dispatch:
+
+name: ci-verify
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: new
+
+      - name: Checkout current master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          path: master
+
+      - name: Download latest flatc g++ binary
+        uses: robinraju/release-downloader@v1.11
+        with:
+          repository: "google/flatbuffers"
+          latest: true
+          fileName: "Linux.flatc.binary.g++*.zip"
+          extract: true
+          # Disabling the default wildcards (*.tar.gz, *.zip)
+          tarBall: false
+          zipBall: false
+
+      - name: Compare specified .fbs files for conformity
+        run: |
+          # Return early if any one of the conformity checks fail
+          set -e
+
+          while IFS= read -r file; do
+            # ignore blank lines
+            [[ -z "$file" ]] && continue
+
+            ./flatc "new/$file" --conform "master/$file"
+          done < ./new/.github/workflows/verify-list

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -44,6 +44,8 @@ jobs:
         run: |
           # Return early if any one of the conformity checks fail
           set -e
+          # Set executable flag
+          chmod u+x ./flatc
 
           while IFS= read -r file; do
             # ignore blank lines

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - master
       - develop
   pull_request:
     branches:

--- a/.github/workflows/verify-list
+++ b/.github/workflows/verify-list
@@ -1,0 +1,5 @@
+HubConfig.fbs
+HubToGatewayMessage.fbs
+GatewayToHubMessage.fbs
+HubToLocalMessage.fbs
+LocalToHubMessage.fbs

--- a/HubConfig.fbs
+++ b/HubConfig.fbs
@@ -4,6 +4,9 @@ table RFConfig {
   /// The GPIO pin connected to the RF modulator's data pin for transmitting (TX)
   tx_pin:int8;
 
+  /// Intentional mistake to test CI
+  rx_pin:int8;
+
   /// Whether to transmit keepalive messages to keep the shockers from entering sleep mode
   keepalive_enabled:bool;
 }

--- a/HubConfig.fbs
+++ b/HubConfig.fbs
@@ -4,9 +4,6 @@ table RFConfig {
   /// The GPIO pin connected to the RF modulator's data pin for transmitting (TX)
   tx_pin:int8;
 
-  /// Intentional mistake to test CI
-  rx_pin:int8;
-
   /// Whether to transmit keepalive messages to keep the shockers from entering sleep mode
   keepalive_enabled:bool;
 }


### PR DESCRIPTION
This PR adds an extra action that runs for pull requests and for pushes to `develop`. Using the flatbuffers compiler's "conformity check", we can automatically ensure we're not running afoul of the Schema Evolution rules [specified here](https://flatbuffers.dev/evolution/).

### Only the schemas listed in `.github/workflows/verify-list` are checked.

Since this implementation of the verification pass relies on `master` branch being an authoritative source, care should be taken to avoid pushing directly to `master` without performing these same checks.