### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,6 +12,9 @@ on:
   workflow_dispatch:
 
 name: ci-build
+permissions:
+  contents: read
+  actions: read
 
 env:
   DOTNET_VERSION: 9.0.x


### PR DESCRIPTION
Potential fix for [https://github.com/OpenShock/flatbuffers-schemas/security/code-scanning/1](https://github.com/OpenShock/flatbuffers-schemas/security/code-scanning/1) and [https://github.com/OpenShock/flatbuffers-schemas/security/code-scanning/2](https://github.com/OpenShock/flatbuffers-schemas/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
- The `contents: read` permission is sufficient for most basic CI tasks, such as checking out the repository and building the solution.
- The `actions: read` permission might be required for downloading artifacts from other workflows.
- Additional permissions, such as `contents: write`, might be needed for uploading artifacts, but this should be verified based on the specific requirements of the `actions/upload-artifact@v4` step.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions to that specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
